### PR TITLE
`server_name` attribute for webmachine needs to be Erlang string

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -64,7 +64,7 @@ default['riak_cs']['config']['riak_cs']['gc_retry_interval'] = 21600
 default['riak_cs']['config']['riak_cs']['dtrace_support'] = false
 
 #webmachine
-default['riak_cs']['config']['webmachine']['server_name'] = "Riak CS"
+default['riak_cs']['config']['webmachine']['server_name'] = "Riak CS".to_erl_string
 default['riak_cs']['config']['webmachine']['log_handlers']['webmachine_log_handler'] = ["/var/log/riak-cs"].to_erl_list
 default['riak_cs']['config']['webmachine']['log_handlers']['riak_cs_access_log_handler'] = [].to_erl_list
 


### PR DESCRIPTION
Without this, the `app.config` for Riak CS is invalid.
