### PR TITLE
Add support for Riak CS Control

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,3 +38,7 @@ suites:
   run_list:
   - recipe[riak-cs::stanchion]
   attributes: {}
+- name: control
+  run_list:
+  - recipe[riak-cs::control]
+  attributes: {}

--- a/attributes/control.rb
+++ b/attributes/control.rb
@@ -1,0 +1,75 @@
+#
+# Author:: Hector Castro (<hector@basho.com>)
+# Cookbook Name:: riak-cs
+#
+# Copyright (c) 2013 Basho Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#package
+default['riak_cs_control']['package']['config_dir'] = "/etc/riak-cs-control"
+default['riak_cs_control']['package']['type'] = "binary"
+default['riak_cs_control']['package']['version']['major'] = "1"
+default['riak_cs_control']['package']['version']['minor'] = "0"
+default['riak_cs_control']['package']['version']['incremental'] = "0"
+default['riak_cs_control']['package']['version']['build'] = "1"
+
+#vm.args
+default['riak_cs_control']['args']['-name'] = "riak-cs-control@#{node['ipaddress']}"
+default['riak_cs_control']['args']['-setcookie'] = "riak-cs-control"
+default['riak_cs_control']['args']['+K'] = true
+default['riak_cs_control']['args']['+A'] = 64
+default['riak_cs_control']['args']['+W'] = "w"
+default['riak_cs_control']['args']['-env']['ERL_MAX_PORTS'] = 4096
+default['riak_cs_control']['args']['-env']['ERL_FULLSWEEP_AFTER'] = 0
+default['riak_cs_control']['args']['-env']['ERL_CRASH_DUMP'] = "/var/log/riak-cs/erl_crash.dump"
+
+#app.config
+class ::String
+  include Eth::Erlang::String
+end
+
+class ::Array
+  include Eth::Erlang::Array
+end
+
+#riak_cs_control
+default['riak_cs_control']['config']['riak_cs_control']['port'] = 8000
+default['riak_cs_control']['config']['riak_cs_control']['cs_hostname'] = "s3.amazonaws.com".to_erl_string
+default['riak_cs_control']['config']['riak_cs_control']['cs_port'] = 80
+default['riak_cs_control']['config']['riak_cs_control']['cs_protocol'] = "http".to_erl_string
+default['riak_cs_control']['config']['riak_cs_control']['cs_proxy_host'] = node['ipaddress'].to_erl_string
+default['riak_cs_control']['config']['riak_cs_control']['cs_proxy_port'] = 8080
+default['riak_cs_control']['config']['riak_cs_control']['cs_admin_key'] = "admin-key".to_erl_string
+default['riak_cs_control']['config']['riak_cs_control']['cs_admin_secret'] = "admin-secret".to_erl_string
+default['riak_cs_control']['config']['riak_cs_control']['cs_administration_bucket'] = "riak-cs".to_erl_string
+
+#lager
+error_log = ["/var/log/riak-cs-control/error.log".to_erl_string,"error",10485760,"$D0".to_erl_string,5].to_erl_tuple
+info_log = ["/var/log/riak-cs-control/console.log".to_erl_string,"info",10485760,"$D0".to_erl_string,5].to_erl_tuple
+default['riak_cs_control']['config']['lager']['handlers']['lager_file_backend'] = [error_log, info_log]
+default['riak_cs_control']['config']['lager']['crash_log'] = "/var/log/riak-cs-control/crash.log".to_erl_string
+default['riak_cs_control']['config']['lager']['crash_log_msg_size'] = 65536
+default['riak_cs_control']['config']['lager']['crash_log_size'] = 10485760
+default['riak_cs_control']['config']['lager']['crash_log_date'] = "$D0".to_erl_string
+default['riak_cs_control']['config']['lager']['crash_log_count'] = 5
+default['riak_cs_control']['config']['lager']['error_logger_redirect'] = true
+
+#sasl
+default['riak_cs_control']['config']['sasl']['sasl_error_logger'] = false
+
+#limits
+default['riak_cs_control']['limits']['maxfiles']['soft'] = 4096
+default['riak_cs_control']['limits']['maxfiles']['hard'] = 4096
+default['riak_cs_control']['limits']['config_limits'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,9 +21,11 @@ name              "riak-cs"
 maintainer        "Basho Technologies, Inc."
 maintainer_email  "riak@basho.com"
 license           "Apache 2.0"
-description       "Installs and configures riak cs"
+description       "Installs and configures Riak CS"
 version           "1.3.0"
 recipe            "riak-cs", "Installs Riak CS"
+recipe            "stanchion", "Installs Stanchion"
+recipe            "control", "Installs Riak CS Control"
 
 %w{ubuntu debian redhat centos scientific oracle amazon}.each do |os|
   supports os

--- a/recipes/control.rb
+++ b/recipes/control.rb
@@ -1,0 +1,111 @@
+#
+# Author:: Hector Castro (<hector@basho.com>)
+# Cookbook Name:: riak-cs
+#
+# Copyright (c) 2013 Basho Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version_str = "#{node['riak_cs_control']['package']['version']['major']}.#{node['riak_cs_control']['package']['version']['minor']}.#{node['riak_cs_control']['package']['version']['incremental']}"
+base_uri = "http://s3.amazonaws.com/downloads.basho.com/riak-cs-control/#{node['riak_cs_control']['package']['version']['major']}.#{node['riak_cs_control']['package']['version']['minor']}/#{version_str}/"
+base_filename = "riak-cs-control-#{version_str}"
+
+case node['riak_cs_control']['package']['type']
+  when "binary"
+    case node['platform']
+    when "ubuntu"
+      machines = {"x86_64" => "amd64", "i386" => "i386", "i686" => "i386"}
+      base_uri = "#{base_uri}#{node['platform']}/#{node['lsb']['codename']}/"
+      package_file = "#{base_filename.gsub(/\-/, '_').sub(/_/,'-').sub(/_/,'-')}-#{node['riak_cs_control']['package']['version']['build']}_#{machines[node['kernel']['machine']]}.deb"
+    when "debian"
+      machines = {"x86_64" => "amd64", "i386" => "i386", "i686" => "i386"}
+      base_uri = "#{base_uri}#{node['platform']}/squeeze/"
+      package_file = "#{base_filename.gsub(/\-/, '_').sub(/_/,'-').sub(/_/,'-')}-#{node['riak_cs_control']['package']['version']['build']}_#{machines[node['kernel']['machine']]}.deb"
+    when "redhat", "centos", "scientific", "amazon"
+      machines = {"x86_64" => "x86_64", "i386" => "i386", "i686" => "i686"}
+      base_uri = "#{base_uri}rhel/#{node['platform_version'].to_i}/"
+      package_file = "#{base_filename}-#{node['riak_cs_control']['package']['version']['build']}.el#{node['platform_version'].to_i}.#{machines[node['kernel']['machine']]}.rpm"
+    when "fedora"
+      machines = {"x86_64" => "x86_64", "i386" => "i386", "i686" => "i686"}
+      base_uri = "#{base_uri}#{node['platform']}/#{node['platform_version'].to_i}/"
+      package_file = "#{base_filename}-#{node['riak_cs_control']['package']['version']['build']}.fc#{node['platform_version'].to_i}.#{node['kernel']['machine']}.rpm"
+    end
+  end
+
+package_uri = base_uri + package_file
+
+package_name = package_file.split("[-_]\d+\.").first
+
+group "riak"
+
+user "riakcs" do
+  gid "riak"
+  shell "/bin/bash"
+  home "/var/lib/riak-cs"
+  system true
+end
+
+remote_file "#{Chef::Config[:file_cache_path]}/#{package_file}" do
+  source package_uri
+  owner "root"
+  mode 0644
+  not_if { File.exists?("#{Chef::Config[:file_cache_path]}#{package_file}") }
+end
+
+directory node['riak_cs_control']['package']['config_dir'] do
+  owner "root"
+  mode "0755"
+  action :create
+end
+
+package package_name do
+  source "#{Chef::Config[:file_cache_path]}/#{package_file}"
+  provider value_for_platform(
+    [ "ubuntu", "debian" ] => {"default" => Chef::Provider::Package::Dpkg},
+    [ "redhat", "centos", "fedora", "suse" ] => {"default" => Chef::Provider::Package::Rpm}
+  )
+  case node['platform'] when "ubuntu","debian"
+    options "--force-confdef --force-confold"
+  end
+  action :install
+end
+
+file "#{node['riak_cs_control']['package']['config_dir']}/app.config" do
+  content Eth::Config.new(node['riak_cs_control']['config'].to_hash).pp
+  owner "root"
+  mode 0644
+  notifies :restart, "service[riak-cs-control]"
+end
+
+file "#{node['riak_cs_control']['package']['config_dir']}/vm.args" do
+  content Eth::Args.new(node['riak_cs_control']['args'].to_hash).pp
+  owner "root"
+  mode 0644
+  notifies :restart, "service[riak-cs-control]"
+end
+
+# Attempted to place an only_if condition on this resource, but Chef
+# would not honor it ...
+if node['riak_cs_control']['limits']['config_limits']
+  file_ulimit "riak-cs-control" do
+    user "riakcs"
+    soft_limit node['riak_cs_control']['limits']['maxfiles']['soft']
+    hard_limit node['riak_cs_control']['limits']['maxfiles']['hard']
+  end
+end
+
+service "riak-cs-control" do
+  supports :start => true, :stop => true, :restart => true
+  action [:enable, :start]
+end


### PR DESCRIPTION
Adding support for Riak CS Control so that [vagrant-riak-cs-cluster](https://github.com/basho/vagrant-riak-cs-cluster) project can configure it automatically.

See: https://github.com/basho/vagrant-riak-cs-cluster/pull/8
