### PR TITLE
Added support for setting file descriptor limits

### DIFF
--- a/attributes/control.rb
+++ b/attributes/control.rb
@@ -68,8 +68,3 @@ default['riak_cs_control']['config']['lager']['error_logger_redirect'] = true
 
 #sasl
 default['riak_cs_control']['config']['sasl']['sasl_error_logger'] = false
-
-#limits
-default['riak_cs_control']['limits']['maxfiles']['soft'] = 4096
-default['riak_cs_control']['limits']['maxfiles']['hard'] = 4096
-default['riak_cs_control']['limits']['config_limits'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,6 +85,4 @@ default['riak_cs']['config']['sasl']['sasl_error_logger'] = false
 default['riak_cs']['config']['sasl']['utc_log'] = true
 
 # limits
-default['riak_cs']['limits']['maxfiles']['soft'] = 4096
-default['riak_cs']['limits']['maxfiles']['hard'] = 4096
-default['riak_cs']['limits']['config_limits'] = false
+default['riak_cs']['limits']['nofile'] = 4096

--- a/attributes/stanchion.rb
+++ b/attributes/stanchion.rb
@@ -68,6 +68,4 @@ default['stanchion']['config']['sasl']['sasl_error_logger'] = false
 default['stanchion']['config']['sasl']['utc_log'] = true
 
 # limits
-default['stanchion']['limits']['maxfiles']['soft'] = 4096
-default['stanchion']['limits']['maxfiles']['hard'] = 4096
-default['stanchion']['limits']['config_limits'] = false
+default['stanchion']['limits']['nofile'] = 4096

--- a/metadata.rb
+++ b/metadata.rb
@@ -27,6 +27,10 @@ recipe            "riak-cs", "Installs Riak CS"
 recipe            "stanchion", "Installs Stanchion"
 recipe            "control", "Installs Riak CS Control"
 
+%w{apt yum ulimit}.each do |d|
+  depends d
+end
+
 %w{ubuntu debian redhat centos scientific oracle amazon}.each do |os|
   supports os
 end

--- a/recipes/control.rb
+++ b/recipes/control.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe "ulimit"
 
 version_str = "#{node['riak_cs_control']['package']['version']['major']}.#{node['riak_cs_control']['package']['version']['minor']}.#{node['riak_cs_control']['package']['version']['incremental']}"
 base_uri = "http://s3.amazonaws.com/downloads.basho.com/riak-cs-control/#{node['riak_cs_control']['package']['version']['major']}.#{node['riak_cs_control']['package']['version']['minor']}/#{version_str}/"
@@ -95,14 +96,8 @@ file "#{node['riak_cs_control']['package']['config_dir']}/vm.args" do
   notifies :restart, "service[riak-cs-control]"
 end
 
-# Attempted to place an only_if condition on this resource, but Chef
-# would not honor it ...
-if node['riak_cs_control']['limits']['config_limits']
-  file_ulimit "riak-cs-control" do
-    user "riakcs"
-    soft_limit node['riak_cs_control']['limits']['maxfiles']['soft']
-    hard_limit node['riak_cs_control']['limits']['maxfiles']['hard']
-  end
+user_ulimit "riakcs" do
+  filehandle_limit node['riak_cs']['limits']['nofile']
 end
 
 service "riak-cs-control" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe "ulimit"
 
 version_str = "#{node['riak_cs']['package']['version']['major']}.#{node['riak_cs']['package']['version']['minor']}.#{node['riak_cs']['package']['version']['incremental']}"
 base_uri = "http://s3.amazonaws.com/downloads.basho.com/riak-cs/#{node['riak_cs']['package']['version']['major']}.#{node['riak_cs']['package']['version']['minor']}/#{version_str}/"
@@ -95,14 +96,8 @@ file "#{node['riak_cs']['package']['config_dir']}/vm.args" do
   notifies :restart, "service[riak-cs]"
 end
 
-# Attempted to place an only_if condition on this resource, but Chef
-# would not honor it ...
-if node['riak_cs']['limits']['config_limits']
-  file_ulimit "riak-cs" do
-    user "riakcs"
-    soft_limit node['riak_cs']['limits']['maxfiles']['soft']
-    hard_limit node['riak_cs']['limits']['maxfiles']['hard']
-  end
+user_ulimit "riakcs" do
+  filehandle_limit node['riak_cs']['limits']['nofile']
 end
 
 service "riak-cs" do

--- a/recipes/stanchion.rb
+++ b/recipes/stanchion.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe "ulimit"
 
 version_str = "#{node['stanchion']['package']['version']['major']}.#{node['stanchion']['package']['version']['minor']}.#{node['stanchion']['package']['version']['incremental']}"
 base_uri = base_uri = "http://s3.amazonaws.com/downloads.basho.com/stanchion/#{node['riak_cs']['package']['version']['major']}.#{node['riak_cs']['package']['version']['minor']}/#{version_str}/"
@@ -100,14 +101,10 @@ file "#{node['stanchion']['package']['config_dir']}/vm.args" do
   notifies :restart, "service[stanchion]"
 end
 
-# Attempted to place an only_if condition on this resource, but Chef
-# would not honor it ...
-if node['stanchion']['limits']['config_limits']
-  file_ulimit "stanchion" do
-    soft_limit node['stanchion']['limits']['maxfiles']['soft']
-    hard_limit node['stanchion']['limits']['maxfiles']['hard']
-  end
+user_ulimit "stanchion" do
+  filehandle_limit node['stanchion']['limits']['nofile']
 end
+
 service "stanchion" do
   supports :start => true, :stop => true, :restart => true
   action [ :enable, :start ]


### PR DESCRIPTION
Support for adding file descriptor limits is achieved via the [ulimit](http://community.opscode.com/cookbooks/ulimit) cookbook. The `include_recipe` bit is required to template `/etc/pam.d/su` so that Riak's init scripts can leverage the newly set file descriptor limit.
