### PR TITLE
Remove allow_mult override from Test Kitchen suite

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -51,8 +51,6 @@ suites:
           minor: 4
           incremental: 1
       config:
-        riak_core:
-          default_bucket_props: [["__tuple", "allow_mult", true]]
         riak_kv:
           storage_backend: riak_cs_kv_multi_backend
 - name: default13
@@ -86,8 +84,6 @@ suites:
           minor: 3
           incremental: 2
       config:
-        riak_core:
-          default_bucket_props: [["__tuple", "allow_mult", true]]
         riak_kv:
           storage_backend: riak_cs_kv_multi_backend
 - name: enterprise
@@ -123,8 +119,6 @@ suites:
           incremental: 1
         enterprise_key: <%= (ENV["RIAK_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_ENTERPRISE_KEY"]) %>
       config:
-        riak_core:
-          default_bucket_props: [["__tuple", "allow_mult", true]]
         riak_kv:
           storage_backend: riak_cs_kv_multi_backend
 - name: enterprise13
@@ -160,7 +154,5 @@ suites:
           incremental: 2
         enterprise_key: <%= (ENV["RIAK_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_ENTERPRISE_KEY"]) %>
       config:
-        riak_core:
-          default_bucket_props: [["__tuple", "allow_mult", true]]
         riak_kv:
           storage_backend: riak_cs_kv_multi_backend

--- a/Berksfile
+++ b/Berksfile
@@ -7,6 +7,6 @@ group :integration do
   cookbook "yum", ">= 2.2.4"
   cookbook "minitest-handler"
 
-  cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.1"
+  cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.2"
   cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.1"
 end


### PR DESCRIPTION
https://github.com/basho/riak-chef-cookbook/pull/86 adds `allow_mult=true` when `riak_cs_kv_multi_backend` is set, therefore we should remove it from being explicitly overwritten in `.kitchen.yml`.
