### PR TITLE
Bump default Riak version to 1.4.2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,7 +15,7 @@ platforms:
       package:
         checksum:
           ubuntu:
-            precise: "3f29736ab0dc8b094272d9caefed4e795ae293f54f79bed8d0464ca821c865ef"
+            precise: "b4e4e31b8e1cd25ea4d3bcd9af94e7322ce1c08645425891574f57ba58f8c516"
     riak_cs:
       package:
         checksum:
@@ -35,7 +35,7 @@ platforms:
       package:
         checksum:
           centos:
-            "6": "a2234d09bdbf08da8b9bf5627b4ea718772fc4964c4d59bd3d4c8ada83d5a9f1"
+            "6": "5bfed85a02df7f297cf20402f147997b06c8ea59dbe860186a54e9dec2dc26e2"
     riak_cs:
       package:
         checksum:
@@ -71,7 +71,7 @@ suites:
       package:
         version:
           minor: 4
-          incremental: 1
+          incremental: 2
       config:
         riak_kv:
           storage_backend: riak_cs_kv_multi_backend
@@ -138,7 +138,7 @@ suites:
       package:
         version:
           minor: 4
-          incremental: 1
+          incremental: 2
         enterprise_key: <%= (ENV["RIAK_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_ENTERPRISE_KEY"]) %>
       config:
         riak_kv:
@@ -173,7 +173,7 @@ suites:
       package:
         version:
           minor: 3
-          incremental: 2
+          incremental: 3
         enterprise_key: <%= (ENV["RIAK_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_ENTERPRISE_KEY"]) %>
       config:
         riak_kv:

--- a/Berksfile
+++ b/Berksfile
@@ -7,6 +7,6 @@ group :integration do
   cookbook "yum", ">= 2.2.4"
   cookbook "minitest-handler"
 
-  cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.2"
+  cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.3.3"
   cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.3.1"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v2.2.2:
 
+* Riak `1.4.2` is now the default.
 * Remove `allow_mult` overrides in Test Kitchen suite.
 * Fixed the `remote_file` resource for Enterprise packages so that it utilizes
   a checksum.


### PR DESCRIPTION
- [x] Test open source Riak CS install
- [x] Test Riak Enterprise install
