### PR TITLE
Tired of waiting for the Omnibus installer to download

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,11 @@ platforms:
     box: opscode-ubuntu-12.04
     box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
     require_chef_omnibus: true
+    require_chef_omnibus: "11.6.0"
+    chef_omnibus_url: https://gist.github.com/hectcastro/6443633/raw/install.sh
+    # Requires a patched version of kitchen-vagrant:
+    # https://github.com/hectcastro/kitchen-vagrant/compare/hc-cachier
+    use_cachier_plugin: true
     customize:
       memory: 512
   run_list:
@@ -26,6 +31,11 @@ platforms:
     box: opscode-centos-6.4
     box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
     require_chef_omnibus: true
+    require_chef_omnibus: "11.6.0"
+    chef_omnibus_url: https://gist.github.com/hectcastro/6443633/raw/install.sh
+    # Requires a patched version of kitchen-vagrant:
+    # https://github.com/hectcastro/kitchen-vagrant/compare/hc-cachier
+    use_cachier_plugin: true
     customize:
       memory: 512
   run_list:


### PR DESCRIPTION
An experimental pull request.

I got tried of waiting for the Omnibus installer to download on the provisionerless Bento boxes. To remedy that, this pull request:
- Replaces the default `install.sh` script with https://gist.github.com/hectcastro/6443633
- Ensures that `require_chef_omnibus` is set to a specific version of Chef and not a boolean
- Adds a `use_cachier_plugin` item via https://github.com/opscode/kitchen-vagrant/pull/37

Results **without** this patch:

``` bash
       Finished converging <default-ubuntu-1204> (7m4.58s).
-----> Setting up <default-ubuntu-1204>
       Finished setting up <default-ubuntu-1204> (0m0.00s).
-----> Verifying <default-ubuntu-1204>
       Finished verifying <default-ubuntu-1204> (0m0.00s).
-----> Destroying <default-ubuntu-1204>
       [kitchen::driver::vagrant command] BEGIN (vagrant destroy -f)
       [default] Forcing shutdown of VM...
       [default] Destroying VM and associated drives...
       [kitchen::driver::vagrant command] END (0m6.87s)
       Vagrant instance <default-ubuntu-1204> destroyed.
       Finished destroying <default-ubuntu-1204> (0m7.53s).
       Finished testing <default-ubuntu-1204> (8m0.01s).
```

Results **with** this patch:

``` bash
       Finished converging <default-ubuntu-1204> (1m29.80s).
-----> Setting up <default-ubuntu-1204>
       Finished setting up <default-ubuntu-1204> (0m0.00s).
-----> Verifying <default-ubuntu-1204>
       Finished verifying <default-ubuntu-1204> (0m0.00s).
-----> Destroying <default-ubuntu-1204>
       [kitchen::driver::vagrant command] BEGIN (vagrant destroy -f)
       [default] Forcing shutdown of VM...
       [default] Destroying VM and associated drives...
       [kitchen::driver::vagrant command] END (0m5.86s)
       Vagrant instance <default-ubuntu-1204> destroyed.
       Finished destroying <default-ubuntu-1204> (0m6.47s).
       Finished testing <default-ubuntu-1204> (2m24.54s).
-----> Kitchen is finished. (2m24.90s)
```
