### PR TITLE
Bump default Riak CS version to 1.4.1 and Riak CS Control to 1.0.2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,7 +25,7 @@ platforms:
       package:
         checksum:
           ubuntu:
-            precise: "9dac7866c94266c23c9bdff0f94e2c697511ef676372ed1c5b615b2486600b3f"
+            precise: "4349a4a9e2aeca766491ca41fdeff4a0946b14cd5aff85d55f872232ae7e483c"
 - name: centos-6.4
   driver_config:
     box: opscode-centos-6.4
@@ -50,7 +50,7 @@ platforms:
       package:
         checksum:
           centos:
-            "6": "a742662649876943bbebac6f0af9e887e33a161d70dea040f8a1102c81c99ccc"
+            "6": "cfd2f4b60ec61aeaf059ef91cc2493b877daf558e3c62e7eb8d4e2a616bdd0e7"
 suites:
 - name: default
   run_list:
@@ -65,19 +65,19 @@ suites:
       package:
         version:
           minor: 4
-          incremental: 0
+          incremental: 1
     stanchion:
       package:
         version:
           minor: 4
-          incremental: 0
+          incremental: 1
     riak_cs_control:
       package:
         version:
           minor: 0
-          incremental: 1
+          incremental: 2
     riak:
-      cs_version: "1.4.0"
+      cs_version: "1.4.1"
       package:
         version:
           minor: 4
@@ -132,19 +132,19 @@ suites:
         enterprise_key: <%= (ENV["RIAK_CS_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_CS_ENTERPRISE_KEY"]) %>
         version:
           minor: 4
-          incremental: 0
+          incremental: 1
     stanchion:
       package:
         version:
           minor: 4
-          incremental: 0
+          incremental: 1
     riak_cs_control:
       package:
         version:
           minor: 0
-          incremental: 1
+          incremental: 2
     riak:
-      cs_version: "1.4.0"
+      cs_version: "1.4.1"
       package:
         version:
           minor: 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.2.3:
+
+* Riak CS `1.4.1` is now the default.
+* Riak CS Control `1.0.2` is now the default.
+
 ## v2.2.2:
 
 * Riak `1.4.2` is now the default.

--- a/attributes/control.rb
+++ b/attributes/control.rb
@@ -22,7 +22,7 @@ default['riak_cs_control']['package']['url'] = "http://s3.amazonaws.com/download
 default['riak_cs_control']['package']['type'] = "binary"
 default['riak_cs_control']['package']['version']['major'] = "1"
 default['riak_cs_control']['package']['version']['minor'] = "0"
-default['riak_cs_control']['package']['version']['incremental'] = "1"
+default['riak_cs_control']['package']['version']['incremental'] = "2"
 default['riak_cs_control']['package']['version']['build'] = "1"
 default['riak_cs_control']['package']['config_dir'] = "/etc/riak-cs-control"
 

--- a/attributes/package.rb
+++ b/attributes/package.rb
@@ -23,6 +23,6 @@ default['riak_cs']['package']['url'] = "http://s3.amazonaws.com/downloads.basho.
 default['riak_cs']['package']['type'] = "binary"
 default['riak_cs']['package']['version']['major'] = "1"
 default['riak_cs']['package']['version']['minor'] = "4"
-default['riak_cs']['package']['version']['incremental'] = "0"
+default['riak_cs']['package']['version']['incremental'] = "1"
 default['riak_cs']['package']['version']['build'] = "1"
 default['riak_cs']['package']['config_dir'] = "/etc/riak-cs"

--- a/attributes/stanchion.rb
+++ b/attributes/stanchion.rb
@@ -22,7 +22,7 @@ default['stanchion']['package']['url'] = "http://s3.amazonaws.com/downloads.bash
 default['stanchion']['package']['type'] = "binary"
 default['stanchion']['package']['version']['major'] = "1"
 default['stanchion']['package']['version']['minor'] = "4"
-default['stanchion']['package']['version']['incremental'] = "0"
+default['stanchion']['package']['version']['incremental'] = "1"
 default['stanchion']['package']['version']['build'] = "1"
 default['stanchion']['package']['config_dir'] = "/etc/stanchion"
 


### PR DESCRIPTION
- [x] Test open source Riak CS and Riak CS Control install
- [x] Test Riak CS Enterprise install
