### PR TITLE
Ensure /etc/default/riak is regenerated on Debian/Ubuntu platform

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,7 +44,7 @@ if node['platform_family'] == "debian"
     content "ulimit -n #{node['riak_cs']['limits']['nofile']}"
     owner "root"
     mode 0644
-    action :create_if_missing
+    action :create
     notifies :restart, "service[riak-cs]"
   end
 else


### PR DESCRIPTION
Resolving this issue https://github.com/basho/riak-chef-cookbook/issues/119 for the Riak CS cookbook.
