### PR TITLE
Updating for Riak CS 1.5

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
   root_path: /home/vagrant/kitchen
 
 platforms:
-- name: ubuntu-13.04
+- name: ubuntu-14.04
   run_list:
   - recipe[apt]
   attributes:
@@ -18,12 +18,12 @@ platforms:
       package:
         checksum:
           ubuntu:
-            precise: "280c816e5dc4a83e3bc5e82d011fed4b3fb83098b81df2997aa17462261c86e6"
+            precise: "f2f5af17cce01a769d31517bbdba5a9e1b99e3581bcc4b33e970dbd0ef4140c6"
     riak_cs:
       package:
         checksum:
           ubuntu:
-            precise: "6d6e8c7e25ebd831a892cc451d38bd00d92b1af9ab0490a061c639d91fa8b2a8"
+            trusty: "d8772b5b8ead8e88e70d08c4f63f7231839f349c9b756805522b306a7705f616"
 - name: ubuntu-12.04
   run_list:
   - recipe[apt]
@@ -32,12 +32,12 @@ platforms:
       package:
         checksum:
           ubuntu:
-            precise: "280c816e5dc4a83e3bc5e82d011fed4b3fb83098b81df2997aa17462261c86e6"
+            precise: "f2f5af17cce01a769d31517bbdba5a9e1b99e3581bcc4b33e970dbd0ef4140c6"
     riak_cs:
       package:
         checksum:
           ubuntu:
-            precise: "6d6e8c7e25ebd831a892cc451d38bd00d92b1af9ab0490a061c639d91fa8b2a8"
+            precise: "e7bd92dac2a7cfe4a051759df0094d31f0f6029805b4baf0d6ae794acc14f1b7"
 - name: debian-7.2.0
   run_list:
   - recipe[apt]
@@ -46,12 +46,12 @@ platforms:
       package:
         checksum:
           debian:
-            "7": "ddc35ba5de39bb31a5f4d1b39627ac6b859dc176ff8a6890d95fb32b3f560589"
+            "7": "3bb6bcc409f51e303978fdb72c8605ac87a502e99bb5b7fda5ecd6af9c343d42"
     riak_cs:
       package:
         checksum:
           debian:
-            "7": "2aec430d568b7d180ffecef33219014f838888ba41be96cfbc4d796c06c715c9"
+            "7": "cd14f18802acaf123f7d5817664dc82bdab214672b7d4f0048cced4d6ec5317c"
 - name: centos-6.5
   run_list:
   - recipe[yum-epel]
@@ -60,12 +60,12 @@ platforms:
       package:
         checksum:
           centos:
-            "6": "2cf9f2481409d2871a6d453a9287f317bd4f5c1cb2e49432f4fee0ac106af56c"
+            "6": "5f93a9ed1d7c9326297ebc432d69d1b03e941c057a7cfa37b45138045efdfb4f"
     riak_cs:
       package:
         checksum:
           centos:
-            "6": "cfaaea1a59fb4b850f5a54825f996fcee96b554c89569dc00d9d2a7e96516a05"
+            "6": "5561c6452f82d0b3d204e30d1943c017bfe2829036c86e2538f296ce0800dde5"
 - name: centos-5.10
   run_list:
   - recipe[yum-epel]
@@ -74,15 +74,52 @@ platforms:
       package:
         checksum:
           centos:
-            "5": "3e6ea55c08c0e0c5d92195955275faed082d0b42fa8bde36e485bbf10b98cae7"
+            "5": "33c54fd0daccca7005bf65e152b4893d4fecd0cd70becdcde596fb935d93625e"
     riak_cs:
       package:
         checksum:
           centos:
-            "5": "11c52f02969f8ce6580a7bad55b09fd2c96a0ef28bc8b98b306cbc0d838f759d"
+            "5": "c29da52a573182453d0d018c81ff6075f5e4f0a0454fd6110993825b78599761"
 
 suites:
 - name: default
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak-cs::package]
+  - recipe[riak]
+  - recipe[riak-cs]
+  - recipe[riak-cs::stanchion]
+  - recipe[riak-cs-create-admin-user]
+  attributes:
+    riak_cs:
+      package:
+        version:
+          major: 1
+          minor: 5
+          incremental: 0
+    stanchion:
+      package:
+        version:
+          major: 1
+          minor: 5
+          incremental: 0
+    riak_cs_control:
+      package:
+        version:
+          major: 1
+          minor: 0
+          incremental: 2
+    riak:
+      cs_version: "1.5.0"
+      package:
+        version:
+          major: 1
+          minor: 4
+          incremental: 10
+      config:
+        riak_kv:
+          storage_backend: riak_cs_kv_multi_backend
+- name: default14
   run_list:
   - recipe[minitest-handler]
   - recipe[riak-cs::package]
@@ -115,7 +152,7 @@ suites:
         version:
           major: 1
           minor: 4
-          incremental: 8
+          incremental: 10
       config:
         riak_kv:
           storage_backend: riak_cs_kv_multi_backend

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.getchef.com"
 
 metadata
 
@@ -7,8 +7,9 @@ group :integration do
   cookbook "yum"
   cookbook "sudo"
   cookbook "minitest-handler"
+  cookbook "packagecloud"
 
-  cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.4.10"
+  cookbook "riak", github: "basho/riak-chef-cookbook", ref: "2.4.14"
   cookbook "riak-cs-create-admin-user", github: "hectcastro/chef-riak-cs-create-admin-user", ref: "0.4.0"
   cookbook "riak-cs-ssl", github: "hectcastro/chef-riak-cs-ssl", ref: "0.2.1"
 end

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ node['riak_cs']['package']['enterprise_key']
 
 ## License and Author
 
-* Author: Sean Carey (<densone@basho.com>), Seth Thomas (<sthomas@basho.com>), Hector Castro (<hector@basho.com>)
-* Copyright (c) 2013 Basho Technologies, Inc.
+* Author: Sean Carey (<densone@basho.com>), 
+* Author: Seth Thomas (<cheeseplus@polycount.com>)
+* Author: Hector Castro (<hector@basho.com>)
+
+* Copyright (c) 2012-2014 Basho Technologies, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/control.rb
+++ b/attributes/control.rb
@@ -1,8 +1,7 @@
 #
-# Author:: Hector Castro (<hector@basho.com>)
 # Cookbook Name:: riak-cs
 #
-# Copyright (c) 2013 Basho Technologies, Inc.
+# Copyright (c) 2013-2014 Basho Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,7 @@
 #
-# Author::Sean Carey (<densone@basho.com>), Seth Thomas (<sthomas@basho.com>)
 # Cookbook Name:: riak-cs
 #
-# Copyright (c) 2012 Basho Technologies, Inc.
+# Copyright (c) 2012-2014 Basho Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,6 +66,7 @@ default['riak_cs']['config']['riak_cs']['storage_archive_period'] = 86400
 default['riak_cs']['config']['riak_cs']['usage_request_limit'] = 744
 default['riak_cs']['config']['riak_cs']['leeway_seconds'] = 86400
 default['riak_cs']['config']['riak_cs']['gc_interval'] = 900
+default['riak_cs']['config']['riak_cs']['gc_paginated_indexes'] = true
 default['riak_cs']['config']['riak_cs']['gc_retry_interval'] = 21600
 default['riak_cs']['config']['riak_cs']['trust_x_forwarded_for'] = false
 default['riak_cs']['config']['riak_cs']['dtrace_support'] = false

--- a/attributes/package.rb
+++ b/attributes/package.rb
@@ -1,8 +1,7 @@
 #
-# Author::Sean Carey (<densone@basho.com>), Seth Thomas (<sthomas@basho.com>)
 # Cookbook Name:: riak-cs
 #
-# Copyright (c) 2013 Basho Technologies, Inc.
+# Copyright (c) 2013-2014 Basho Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +21,7 @@ default['riak_cs']['package']['enterprise_key'] = ""
 default['riak_cs']['package']['url'] = "http://s3.amazonaws.com/downloads.basho.com/riak-cs"
 default['riak_cs']['package']['type'] = "binary"
 default['riak_cs']['package']['version']['major'] = "1"
-default['riak_cs']['package']['version']['minor'] = "4"
-default['riak_cs']['package']['version']['incremental'] = "5"
+default['riak_cs']['package']['version']['minor'] = "5"
+default['riak_cs']['package']['version']['incremental'] = "0"
 default['riak_cs']['package']['version']['build'] = "1"
 default['riak_cs']['package']['config_dir'] = "/etc/riak-cs"

--- a/attributes/stanchion.rb
+++ b/attributes/stanchion.rb
@@ -1,8 +1,7 @@
 #
-# Author::Sean Carey (<densone@basho.com>), Seth Thomas (<sthomas@basho.com>)
 # Cookbook Name:: riak_cs
 #
-# Copyright (c) 2013 Basho Technologies, Inc.
+# Copyright (c) 2013-2014 Basho Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +20,8 @@
 default['stanchion']['package']['url'] = "http://s3.amazonaws.com/downloads.basho.com/stanchion"
 default['stanchion']['package']['type'] = "binary"
 default['stanchion']['package']['version']['major'] = "1"
-default['stanchion']['package']['version']['minor'] = "4"
-default['stanchion']['package']['version']['incremental'] = "3"
+default['stanchion']['package']['version']['minor'] = "5"
+default['stanchion']['package']['version']['incremental'] = "0"
 default['stanchion']['package']['version']['build'] = "1"
 default['stanchion']['package']['config_dir'] = "/etc/stanchion"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -34,6 +34,7 @@ depends "riak", "~> 2.4.10"
 depends "ulimit", "~> 0.3.2"
 depends "yum", "~> 3.0"
 depends "yum-epel", "~> 0.3"
+depends "packagecloud"
 
 %w{ubuntu debian redhat centos scientific oracle amazon}.each do |os|
   supports os

--- a/recipes/control.rb
+++ b/recipes/control.rb
@@ -1,8 +1,7 @@
 #
-# Author:: Hector Castro (<hector@basho.com>)
 # Cookbook Name:: riak-cs
 #
-# Copyright (c) 2013 Basho Technologies, Inc.
+# Copyright (c) 2013-2014 Basho Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/enterprise_package.rb
+++ b/recipes/enterprise_package.rb
@@ -1,9 +1,8 @@
 #
-# Author:: Hector Castro (<hector@basho.com>)
 # Cookbook Name:: riak-cs
 # Recipe:: enterprise_package
 #
-# Copyright (c) 2013 Basho Technologies, Inc.
+# Copyright (c) 2013-2014 Basho Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -1,9 +1,8 @@
 #
-# Author:: Hector Castro (<hector@basho.com>)
 # Cookbook Name:: riak-cs
 # Recipe:: package
 #
-# Copyright (c) 2013 Basho Technologies, Inc.
+# Copyright (c) 2013-2014 Basho Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,12 +25,9 @@ package_version = "#{version_str}-#{node['riak_cs']['package']['version']['build
 
 case node['platform_family']
 when "debian"
-  apt_repository "basho" do
-    uri "http://apt.basho.com"
-    distribution (node['lsb']['codename'] == "raring" ? "precise" : node['lsb']['codename'])
 
-    components ["main"]
-    key "http://apt.basho.com/gpg/basho.apt.key"
+  packagecloud_repo "basho/riak-cs" do
+    type "deb"
   end
 
   package "riak-cs" do
@@ -44,11 +40,9 @@ when "rhel"
   elsif node['platform'] == "amazon"
     platform_version = 5
   end
-  yum_repository "basho" do
-    description "Basho Stable Repo"
-    url "http://yum.basho.com/el/#{platform_version}/products/x86_64/"
-    gpgkey "http://yum.basho.com/gpg/RPM-GPG-KEY-basho"
-    action :add
+
+  packagecloud_repo "basho/riak-cs" do
+    type "rpm"
   end
 
   if platform_version >= 6

--- a/recipes/stanchion.rb
+++ b/recipes/stanchion.rb
@@ -1,9 +1,7 @@
 #
-# Author:: Sean Carey (<densone@basho.com>), Seth Thomas (<sthomas@basho.com>),
-#          Hector Castro (<hector@basho.com>)
 # Cookbook Name:: riak-cs
 #
-# Copyright (c) 2013 Basho Technologies, Inc.
+# Copyright (c) 2013-2014 Basho Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 include_recipe "ulimit" unless node['platform_family'] == "debian"
 
 version_str = "#{node['stanchion']['package']['version']['major']}.#{node['stanchion']['package']['version']['minor']}.#{node['stanchion']['package']['version']['incremental']}"
@@ -27,11 +26,8 @@ package_version = "#{version_str}-#{node['riak_cs']['package']['version']['build
 
 case node['platform_family']
 when "debian"
-  apt_repository "basho" do
-    uri "http://apt.basho.com"
-    distribution (node['lsb']['codename'] == "raring" ? "precise" : node['lsb']['codename'])
-    components ["main"]
-    key "http://apt.basho.com/gpg/basho.apt.key"
+  packagecloud_repo "basho/riak-cs" do
+    type "deb"
   end
 
   package "stanchion" do
@@ -44,11 +40,9 @@ when "rhel"
   elsif node['platform'] == "amazon"
     platform_version = 5
   end
-  yum_repository "basho" do
-    description "Basho Stable Repo"
-    url "http://yum.basho.com/el/#{platform_version}/products/x86_64/"
-    gpgkey "http://yum.basho.com/gpg/RPM-GPG-KEY-basho"
-    action :add
+
+  packagecloud_repo "basho/riak-cs" do
+    type "rpm"
   end
 
   if platform_version >= 6


### PR DESCRIPTION
- Update Riak cookbook for 2.4.14 (riak 1.4.10)
- Moving Authors to README, updating copyright
- Added packagebutt support
- Remove Ubuntu 13.04 support (EOL)
- Add Ubuntu 14.04 support
